### PR TITLE
Start using there-and-back-again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ Package Control.last-run
 Package Control.merged-ca-bundle
 Package Control.user-ca-bundle
 oscrypto-ca-bundle.crt
+
+.meta-project/node_modules

--- a/.meta-project/README.md
+++ b/.meta-project/README.md
@@ -1,0 +1,37 @@
+# .meta-project
+
+The project, [sublime-settings], is a collection of the files that comprise my
+Sublime 3 Configuration.
+
+[sublime-settings]: https://github.com/jedcn/sublime-settings
+
+*This directory* contains files that manage the configuration, but *aren't
+used* by Sublime 3 itself.
+
+Some of these files are stored both in a bare config file and a corresponding
+markdown file with [there-and-back-again].
+
+[there-and-back-again]: https://github.com/jedcn/there-and-back-again
+
+This NPM based functionality is made possible with a [package.json] and
+[some shell scripts].
+
+[package.json]: ./package.json
+[some shell scripts]: ./bin
+
+Lastly, there's a pair of functions that allow you to type:
+
+* `update`: Update markdown files from changed config files
+* `extract`: Extract config files from changed markdown files
+
+## Getting Started
+
+You can define `update` and `extract` by running the following command from the
+root of this [project][sublime-settings].
+
+```shell
+source .meta-project/source.me
+```
+
+Once you've run this command, you can run `update` or `extract` from wherever
+you'd like-- they know to come back to this project before they run.

--- a/.meta-project/bin/extract-config-from-markdown
+++ b/.meta-project/bin/extract-config-from-markdown
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+function extract_config_from_markdown {
+  config_file="$1"
+  markdown_file="${config_file}.md"
+  extract=".meta-project/node_modules/there-and-back-again/bin/extract-config-from-markdown"
+  $extract --markdown-file "$markdown_file" --config-file "$config_file"
+}
+
+pushd ../
+extract_config_from_markdown Default\ \(OSX\).sublime-keymap
+popd

--- a/.meta-project/bin/update-markdown-from-config
+++ b/.meta-project/bin/update-markdown-from-config
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+function update_markdown_from_config {
+  config_file="$1"
+  markdown_file="${config_file}.md"
+  update=".meta-project/node_modules/there-and-back-again/bin/update-markdown-from-config"
+  $update --markdown-file "$markdown_file" --config-file "$config_file" --force true
+}
+
+pushd ../
+update_markdown_from_config Default\ \(OSX\).sublime-keymap
+popd

--- a/.meta-project/package.json
+++ b/.meta-project/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "sublime-settings",
+  "version": "1.0.0",
+  "description": "Jed's Sublime Settings",
+  "main": "index.js",
+  "scripts": {
+    "update-markdown-from-config": "./bin/update-markdown-from-config",
+    "extract-config-from-markdown": "./bin/extract-config-from-markdown"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jedcn/sublime-settings.git"
+  },
+  "author": "jedcn",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/jedcn/sublime-settings/issues"
+  },
+  "homepage": "https://github.com/jedcn/sublime-settings#readme",
+  "dependencies": {
+    "there-and-back-again": "^0.1.1"
+  }
+}

--- a/.meta-project/source.me
+++ b/.meta-project/source.me
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+ABSOLUTE_PARENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+META_PROJECT_DIR=$ABSOLUTE_PARENT_DIR/.meta-project
+
+function extract {
+  pushd $META_PROJECT_DIR
+  npm run extract-config-from-markdown
+  popd
+}
+
+function update {
+  pushd $META_PROJECT_DIR
+  npm run update-markdown-from-config
+  popd
+}

--- a/Default (OSX).sublime-keymap.md
+++ b/Default (OSX).sublime-keymap.md
@@ -1,4 +1,18 @@
+# Default (OSX).sublime-keymap
+
+```
 [
+```
+
+## Movement and Selection
+
+Sometimes I move my cursor up and down lines with the arrow keys, but I often
+will use `CTRL+P` (up) and `CTRL+N` (down).
+
+The following extends those two commands so that holding `SHIFT` causes you to
+expand your selection up or down lines.
+
+```
     {
         "keys": [
             "ctrl+shift+p"
@@ -21,6 +35,21 @@
         },
         "command": "move"
     },
+```
+
+## Pasting and Indentation
+
+### `SUPER+v` and `SHIFT+SUPER+v`
+
+By default `SUPER+v` pastes code and `SHIFT+SUPER+v` pastes *and* indents code.
+The following config reverses that logic because, hey, if you paste, you're
+going to indent, eh?
+
+I learned this in this [Wes Bos' post][wes-bos-tips].
+
+[wes-bos-tips]: http://wesbos.com/5-sublime-text-tweaks-tips/
+
+```
     {
         "keys": [
             "super+v"
@@ -33,12 +62,27 @@
         ],
         "command": "paste"
     },
+```
+
+### `SUPER+SHIFT+r`
+
+If you've selected text and press this key combo, Sublime will re-indent your
+selection.
+
+```
     {
         "keys": [
             "super+shift+r"
         ],
         "command": "reindent"
     },
+```
+
+## Emmet
+
+I thought this would be cool, but I'm not been using it. Maybe remove?
+
+```
     {
         "keys": [
             "ctrl+m"
@@ -63,12 +107,37 @@
         },
         "command": "move_to"
     },
+```
+
+## Wrapping Lines
+
+```
     {
         "keys": [
             "super+q"
         ],
         "command": "wrap_lines_plus"
     },
+```
+
+## GitSavvy
+
+There's a ton of stuff here.
+
+### Core Keybindings
+
+GitSavvy is "activated" in Sublime and then it becomes useful in a new window.
+To get going I use the following commands:
+
+* `SUPER+'+s`: Show Git Status
+* `SUPER+'+l`: Show Graph of Commits
+* `SUPER+'+d+d`: Show a Diff (unstaged)
+* `SUPER+'+d+c`, `SUPER+'+d+s`: Show Diff (cached aka staged)
+* `SUPER+'+c`: Open up a prompt and commit
+
+#### `SUPER+'+s`
+
+```
     {
         "keys": [
             "super+'",
@@ -76,6 +145,11 @@
         ],
         "command": "gs_show_status"
     },
+```
+
+#### `SUPER+'+l`
+
+```
     {
         "keys": [
             "super+'",
@@ -83,6 +157,11 @@
         ],
         "command": "gs_log_graph_current_branch"
     },
+```
+
+#### `SUPER+'+d+d`
+
+```
     {
         "keys": [
             "super+'",
@@ -91,6 +170,11 @@
         ],
         "command": "gs_diff"
     },
+```
+
+#### `SUPER+'+d+c`, `SUPER+'+d+s`
+
+```
     {
         "keys": [
             "super+'",
@@ -113,6 +197,14 @@
         },
         "command": "gs_diff"
     },
+```
+
+### Git Diff
+
+When looking at a diff, if you use `CTRL+P` or `CTRL+N` you navigate between
+sets of changes. I then use arrow keys to navigate within those sets.
+
+```
     {
         "keys": [
             "ctrl+n"
@@ -155,6 +247,11 @@
              }
          ]
      },
+```
+
+And when you're done looking at a diff you can press `q` to leave immediately.
+
+```
      {
          "keys": [
              "q"
@@ -173,6 +270,13 @@
              }
          ]
      },
+```
+
+### Git Graph
+
+Press `q` to leave immediately.
+
+```
      {
          "keys": [
              "q"
@@ -191,6 +295,13 @@
              }
          ]
      },
+```
+
+### Git Status
+
+Press `q` to leave immediately.
+
+```
      {
          "keys": [
              "q"
@@ -209,6 +320,11 @@
              }
          ]
      },
+```
+
+Use `CTRL+P` or `CTRL+N` you navigate between files within the status.
+
+```
      {
          "keys": [
              "ctrl+n"
@@ -251,6 +367,13 @@
              }
          ]
      },
+```
+
+### `SUPER+'+c`
+
+Quickly commit whatever's been staged.
+
+```
      {
         "keys": [
             "super+'",
@@ -258,4 +381,8 @@
         ],
         "command": "gs_quick_commit"
     },
+```
+
+```
 ]
+```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [here][packages].
 
 See [here][keybindings].
 
-[keybindings]: ./Default%20(OSX).sublime-keymap
+[keybindings]: ./Default%20(OSX).sublime-keymap.md
 
 ## Snippets I Use ##
 
@@ -18,3 +18,8 @@ See [here][snippets].
 
 [snippets]: ./snippets
 
+## Markdown and Configs ##
+
+Some configuration files are stored as markdown. See [.meta-project/README.md].
+
+[.meta-project/README.md]: ./.meta-project/README.md


### PR DESCRIPTION
# Overview

This is a first attempt to use https://github.com/jedcn/there-and-back-again to put my config into a markdown file.

I'm getting ready to publish a new version of https://github.com/jedcn/there-and-back-again and I'm testing the command line executables in a simple case.

Not sure how this will work out, but I'm happy so far! /cc @banderson @a-bash

## What's happening here?

* I had a file named `Default (OSX).sublime-keymap` that was primarily JSON but also allowed comments.
* This is a sublime configuration file that contains keybindings described in JSON.
* I created a markdown file named `Default (OSX).sublime-keymap.md` by running a tool from there-and-back-again: `create-markdown-from-config --config-file Default\ \(OSX\).sublime-keymap`
* Initially this file contained simple markdown with a single code block
* I then went through the larger code block and broke it into many smaller code blocks.
* I removed documentation that was inline in the JSON as comments and wrote it out as english prose in Markdown. In one case I added a proper markdown link.
* Then, having made changes to the markdown, I ran another tool from there-and-back-again like so `extract-config-from-markdown --config-file Default\ \(OSX\).sublime-keymap --markdown-file Default\ \(OSX\).sublime-keymap.md`.
* This took what was in the markdown file and wrote it back out to the original file. The difference (as you can see in this PR) is that the comments are removed.. but that's it! Now the comments live in an easier place to read-- the markdown file.

## Where is this going?

I am hoping that the tools in `there-and-back-again` will allow the following work flow:

* My editor (Sublime) will know how to work with `Default (OSX).sublime-keymap` and I can experiment with config changes there.
* Once I get a config change that I like, I can run `update-markdown-from-config` to update `Default (OSX).sublime-keymap.md` and this will update the markdown file.
* I can modify the markdown file with proper documentation and links. I'll be able to share the markdown file with people.

So-- the JSON file can be used by my editor, the markdown file is easily read by human beings, and the tools in `there-and-back-again` let me sync between the two.

And so-- the whole point of this is that config file still works with Sublime *and* I can say to you, "Check out my sublime config by [looking here][markdown-file-in-pr]"

[markdown-file-in-pr]: https://github.com/jedcn/sublime-settings/blob/5cbd74a84ea61bfb33e68fc2a791653e860aa6d0/Default%20(OSX).sublime-keymap.md

## yes, yes, fine, fine, but who cares about json editor configs?

Some people do-- and I think this will help them share.

But there's nothing about there-and-back-again that limits it to Sublime. Or JSON.

✊ ✊ ☝️ 

## TODO

* [x] Publish there-and-back-again at its current `master`
* [x] Setup some script / `makefile` / whatever that makes it easy to convert between `md` and config files
* [x] Document said setup
* [ ] Squash